### PR TITLE
Add SVG overlay highlighting and serve script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ Burrow is an HTML, markdown, and SVG viewer, code editor, and debugger built wit
 Before build commands can be run `npm` must be installed and dependencies must be installed with `npm install`. 
 
 To create and run a development distribution run `npm start` and to create a production build run `npm run build`. To lint your code for issues, run `npm run lint`.
+
+After building you can serve the output over HTTP so other devices on your LAN can access it by running `npm run serve`. This will start a local server on port 8080 serving the `build` directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"file-loader": "^6.2.0",
 				"html-loader": "^5.0.0",
 				"html-webpack-plugin": "^5.6.0",
+				"http-server": "^14.1.1",
 				"less": "^4.2.0",
 				"less-loader": "^12.2.0",
 				"mini-css-extract-plugin": "^2.9.0",
@@ -2199,6 +2200,26 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "5.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/basic-auth/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -2528,6 +2549,23 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/callsites": {
@@ -2949,6 +2987,16 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/corser": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+			"integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
 		},
 		"node_modules/crc": {
 			"version": "3.8.0",
@@ -4321,6 +4369,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -4585,6 +4640,27 @@
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
@@ -5037,6 +5113,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/html-loader": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/html-loader/-/html-loader-5.1.0.tgz",
@@ -5192,6 +5281,21 @@
 			"dev": true,
 			"license": "BSD-2-Clause"
 		},
+		"node_modules/http-proxy": {
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^4.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5204,6 +5308,47 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/http-server": {
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+			"integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"basic-auth": "^2.0.1",
+				"chalk": "^4.1.2",
+				"corser": "^2.0.1",
+				"he": "^1.2.0",
+				"html-encoding-sniffer": "^3.0.0",
+				"http-proxy": "^1.18.1",
+				"mime": "^1.6.0",
+				"minimist": "^1.2.6",
+				"opener": "^1.5.1",
+				"portfinder": "^1.0.28",
+				"secure-compare": "3.0.1",
+				"union": "~0.5.0",
+				"url-join": "^4.0.1"
+			},
+			"bin": {
+				"http-server": "bin/http-server"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/http-server/node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/http2-wrapper": {
@@ -6661,6 +6806,19 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -6696,6 +6854,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/opener": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+			"dev": true,
+			"license": "(WTFPL OR MIT)",
+			"bin": {
+				"opener": "bin/opener-bin.js"
 			}
 		},
 		"node_modules/optionator": {
@@ -7104,6 +7272,20 @@
 				"node": ">=10.4.0"
 			}
 		},
+		"node_modules/portfinder": {
+			"version": "1.0.37",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
+			"integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async": "^3.2.6",
+				"debug": "^4.3.6"
+			},
+			"engines": {
+				"node": ">= 10.12"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -7353,6 +7535,22 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/qs": {
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7487,6 +7685,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/resedit": {
 			"version": "1.7.2",
@@ -7738,6 +7943,13 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/secure-compare": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+			"integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -7859,6 +8071,82 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || >=14"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/signal-exit": {
@@ -8666,6 +8954,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/union": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+			"integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+			"dev": true,
+			"dependencies": {
+				"qs": "^6.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/unique-filename": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
@@ -8743,6 +9043,13 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"node_modules/url-join": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/utf8-byte-length": {
 			"version": "1.0.5",
@@ -9045,6 +9352,19 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/when-exit": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"start": "webpack --mode=development && electron .",
 		"build": "webpack --mode=production && electron-builder --publish never",
 		"release": "webpack --mode=production && electron-builder",
-		"lint": "eslint --ext .ts ."
+                "lint": "eslint --ext .ts .",
+                "serve": "npx http-server build -a 0.0.0.0 -p 8080"
 	},
 	"repository": {
 		"type": "git",
@@ -41,7 +42,8 @@
 		"ts-loader": "^9.5.1",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.5.3",
-		"webpack-cli": "^6.0.1"
+                "webpack-cli": "^6.0.1",
+                "http-server": "^14.1.1"
 	},
 	"dependencies": {
 		"@prettier/plugin-xml": "^3.4.1",

--- a/src/window/Tab.ts
+++ b/src/window/Tab.ts
@@ -255,16 +255,57 @@ export default class Tab {
 		}
 	}
 	
-	async linkDevtools() {
-		await this.webviewReady;
-		await this.devtoolsReady;
+        async linkDevtools() {
+                await this.webviewReady;
+                await this.devtoolsReady;
 
-		ipcRenderer.send(
-			'set-devtool-webview',
-			this.webview.getWebContentsId(),
-			this.devtools.getWebContentsId()
-		);
-	}
+                ipcRenderer.send(
+                        'set-devtool-webview',
+                        this.webview.getWebContentsId(),
+                        this.devtools.getWebContentsId()
+                );
+        }
+
+        async highlightSvgElement(id?: string) {
+                await this.webviewReady;
+
+                const js = `(() => {
+                        let overlay = window.__burrowSvgOverlay;
+                        if (!overlay) {
+                                overlay = document.createElement('div');
+                                overlay.style.position = 'absolute';
+                                overlay.style.pointerEvents = 'none';
+                                overlay.style.background = 'rgba(255,0,0,0.15)';
+                                overlay.style.outline = '2px dashed rgba(255,0,0,0.5)';
+                                overlay.style.zIndex = '999999';
+                                window.__burrowSvgOverlay = overlay;
+                                document.body.appendChild(overlay);
+                        }
+
+                        const id = ${id ? JSON.stringify(id) : 'null'};
+
+                        if (!id) {
+                                overlay.style.display = 'none';
+                                return;
+                        }
+
+                        const el = document.getElementById(id);
+
+                        if (!el) {
+                                overlay.style.display = 'none';
+                                return;
+                        }
+
+                        const rect = el.getBoundingClientRect();
+                        overlay.style.display = '';
+                        overlay.style.left = rect.left + 'px';
+                        overlay.style.top = rect.top + 'px';
+                        overlay.style.width = rect.width + 'px';
+                        overlay.style.height = rect.height + 'px';
+                })();`;
+
+                this.webview.executeJavaScript(js).catch(() => { });
+        }
 	
 	async save(saveType = SaveType.Standard): Promise<boolean> {
 		const value = this.editorSession.getValue();

--- a/src/window/window.ts
+++ b/src/window/window.ts
@@ -119,6 +119,45 @@ if (openFiles.length) {
 window.htmlClipboard = new HTMLClipboard(editor);
 window.formatEditor = () => format(editor, tabs.currentTab.mode, settings);
 
+function findSvgElementId(text: string, index: number): string | undefined {
+        let pos = text.lastIndexOf('<', index);
+        while (pos >= 0) {
+                const char = text[pos + 1];
+                if (char && char !== '/' && char !== '!' && char !== '?') {
+                        const end = text.indexOf('>', pos);
+                        if (end === -1) return undefined;
+                        const tag = text.slice(pos, end + 1);
+                        const match = tag.match(/id\s*=\s*['"]([^'"]+)['"]/);
+                        if (match) return match[1];
+                }
+                pos = text.lastIndexOf('<', pos - 1);
+        }
+        return undefined;
+}
+
+async function updateSvgOverlay() {
+        const tab = tabs.currentTab;
+
+        if (tab.mode !== 'svg') {
+                tab.highlightSvgElement(undefined);
+                return;
+        }
+
+        const pos = editor.getCursorPosition();
+        const index = tab.editorSession.doc.positionToIndex(pos);
+        const id = findSvgElementId(tab.editorSession.getValue(), index);
+        tab.highlightSvgElement(id);
+}
+
+editor.selection.on('changeCursor', updateSvgOverlay);
+editor.on('change', updateSvgOverlay);
+
+const origSelectTab = tabs.selectTab.bind(tabs);
+tabs.selectTab = (tab) => {
+        origSelectTab(tab);
+        updateSvgOverlay();
+};
+
 let forceClose = false;
 window.addEventListener('beforeunload', async e => {
 	if (forceClose || !tabs.tabs.some(tab => tab.unsaved)) return;


### PR DESCRIPTION
## Summary
- add HTTP serve script for built assets and document it
- highlight SVG nodes in the preview when the cursor moves in SVG source

## Testing
- `npm run lint`
- `npm run build` *(fails: cancelled by SIGINT)*

------
https://chatgpt.com/codex/tasks/task_e_687b6f8a6dc0832bb7a215948b5a9ea2